### PR TITLE
Fix LIST and UIDL with msg-nbr, added LAST command

### DIFF
--- a/src/Command.mjs
+++ b/src/Command.mjs
@@ -32,10 +32,13 @@ class Pop3Command extends Pop3Connection {
 
   async UIDL(msgNumber = '') {
     await this._connect();
-    const [, stream] = await super.command('UIDL', msgNumber);
-    const str = await stream2String(stream);
-    const list = listify(str);
-    return msgNumber ? list[0] : list;
+    const [info, stream] = await super.command('UIDL', msgNumber);
+    if (msgNumber) {
+        return listify(info)[0];
+    } else {
+        const str = await stream2String(stream);
+        return listify(str);
+    }
   }
 
   async NOOP() {
@@ -46,10 +49,13 @@ class Pop3Command extends Pop3Connection {
 
   async LIST(msgNumber = '') {
     await this._connect();
-    const [, stream] = await super.command('LIST', msgNumber);
-    const str = await stream2String(stream);
-    const list = listify(str);
-    return msgNumber ? list[0] : list;
+    const [info, stream] = await super.command('LIST', msgNumber);
+    if (msgNumber) {
+        return listify(info)[0];
+    } else {
+        const str = await stream2String(stream);
+        return listify(str);
+    }
   }
 
   async RSET() {
@@ -73,6 +79,12 @@ class Pop3Command extends Pop3Connection {
   async STAT() {
     await this._connect();
     const [info] = await super.command('STAT');
+    return info;
+  }
+
+  async LAST() {
+    await this._connect();
+    const [info] = await super.command('LAST');
     return info;
   }
 

--- a/src/Connection.mjs
+++ b/src/Connection.mjs
@@ -8,7 +8,8 @@ import {
   CRLF_BUFFER,
   TERMINATOR_BUFFER,
   TERMINATOR_BUFFER_ARRAY,
-  MULTI_LINE_COMMAND_NAME
+  MULTI_LINE_COMMAND_NAME,
+  MAYBE_MULTI_LINE_COMMAND_NAME
 } from './constant.mjs';
 
 class Pop3Connection extends EventEmitter {
@@ -99,9 +100,10 @@ class Pop3Connection extends EventEmitter {
         if (buffer[0] === 43) { // '+'
           const firstLineEndIndex = buffer.indexOf(CRLF_BUFFER);
           const infoBuffer = buffer.slice(4, firstLineEndIndex);
-          const [commandName] = (this._command || '').split(' ');
+          const [commandName, msgNumber] = (this._command || '').split(' ');
           let stream = null;
-          if (MULTI_LINE_COMMAND_NAME.includes(commandName)) {
+          if (MULTI_LINE_COMMAND_NAME.includes(commandName) ||
+              !msgNumber && MAYBE_MULTI_LINE_COMMAND_NAME.includes(commandName)) {
             this._updateStream();
             stream = this._stream;
             const bodyBuffer = buffer.slice(firstLineEndIndex + 2);

--- a/src/constant.mjs
+++ b/src/constant.mjs
@@ -8,8 +8,10 @@ export const TERMINATOR_BUFFER_ARRAY = [
 ];
 
 export const MULTI_LINE_COMMAND_NAME = [
-  'LIST',
   'RETR',
   'TOP',
+];
+export const MAYBE_MULTI_LINE_COMMAND_NAME = [
+  'LIST',
   'UIDL',
 ];

--- a/test/programmatic.mjs
+++ b/test/programmatic.mjs
@@ -37,6 +37,15 @@ describe('Programmatic', async function () {
     await pop3Command.QUIT();
     expect(info).to.be.a('string');
   });
+  it('Runs LAST command', async function () {
+    const pop3Command = new Pop3Command(config);
+    await pop3Command.connect();
+    await pop3Command.command('USER', config.user);
+    await pop3Command.command('PASS', config.password);
+    const info = await pop3Command.LAST();
+    await pop3Command.QUIT();
+    expect(info).to.be.a('string');
+  });
   it('Runs NOOP command', async function () {
     const pop3Command = new Pop3Command(config);
     await pop3Command.connect();
@@ -64,9 +73,7 @@ describe('Programmatic', async function () {
     await pop3Command.QUIT();
     expect(list).to.be.an('array');
   });
-  // Not sure why not getting server responses for these despite passing
-  //   on command
-  it.skip('Runs LIST command with message', async function () {
+  it('Runs LIST command with message number', async function () {
     const pop3Command = new Pop3Command(config);
     await pop3Command.connect();
     await pop3Command.command('USER', config.user);
@@ -75,7 +82,7 @@ describe('Programmatic', async function () {
     await pop3Command.QUIT();
     expect(list).to.be.an('array');
   });
-  it.skip('Runs UIDL command with message', async function () {
+  it('Runs UIDL command with message number', async function () {
     const pop3Command = new Pop3Command(config);
     await pop3Command.connect();
     await pop3Command.command('USER', config.user);


### PR DESCRIPTION
My testing found that the LIST and UIDL commands hang when a message number is supplied.  This was caused by a multi-line stream always being created.  When a message number is present, the data is only in the `info` response and no stream is needed.

I also added the LAST command as it is useful for stateful clients.